### PR TITLE
Make Service Type variable

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -88,6 +88,15 @@ as defined in https://www.freedesktop.org/software/systemd/man/systemd.timer.htm
 
 Default value: "timer for ${service_description}"
 
+##### `type`
+
+Data type: `String`
+
+type of the systemd service as defined in
+https://www.freedesktop.org/software/systemd/man/systemd.service.html
+
+Default value: 'oneshot'
+
 ##### `user`
 
 Data type: `String`

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -68,6 +68,7 @@ define systemd_cron (
       'description'       => $service_description,
       'command'           => $command,
       'user'              => $user,
+      'type'              => $type,
       'additional_params' => $additional_service_params,
       }
     ),

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,6 +13,8 @@
 # @param ensure removes the instance if set to false or absent
 # @param timer_description optional string for Description= defintion of the service
 #  as defined in https://www.freedesktop.org/software/systemd/man/systemd.timer.html
+# @param type type of service as defined in
+#  https://www.freedesktop.org/software/systemd/man/systemd.service.html
 # @param user username to run command User= as defined in
 #  https://www.freedesktop.org/software/systemd/man/systemd.service.html
 # @param additional_timer_params optional array with lines to append to [Timer] section
@@ -36,6 +38,7 @@ define systemd_cron (
   Optional[Variant[Integer,String]]         $on_unitactive_sec         = undef,
   String                                    $timer_description         = "timer for ${service_description}",
   Variant[Boolean,Enum['present','absent']] $ensure                    = true,
+  String                                    $type                      = 'oneshot',
   String                                    $user                      = 'root',
   Optional[Array]                           $additional_timer_params   = undef,
   Optional[Array]                           $additional_service_params = undef,

--- a/spec/defines/init_spec.rb
+++ b/spec/defines/init_spec.rb
@@ -43,6 +43,10 @@ describe 'systemd_cron' do
         }
         it {
           is_expected.to contain_file("/etc/systemd/system/#{title}_cron.service")
+            .with_content(%r{Type=oneshot})
+        }
+        it {
+          is_expected.to contain_file("/etc/systemd/system/#{title}_cron.service")
             .with_content(%r{User=root})
         }
 

--- a/templates/service.epp
+++ b/templates/service.epp
@@ -4,7 +4,7 @@
 Description=<%= $description %>
 
 [Service]
-Type=oneshot
+Type=<%= $type %>
 ExecStart=<%= $command %>
 User=<%= $user %>
 <% unless $additional_params =~ Undef {


### PR DESCRIPTION
Currently the used service type is oneshot. This is a good choice for most.

However, I came across an issue that I need systemd to restart the service on failure. This sadly is not possible with oneshot, but it is with simple.

Anyhow, I would be happy if you could merge this and create a new tag. Thanks!