### PR TITLE
Ignore missing command  if `ensure` is not set to `present`

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -128,11 +128,11 @@ define systemd_cron (
     unit_entry    => delete_undef_values({
         'Description' => $service_description ,
     }) + $service_unit_overrides,
-    service_entry => {
-      'ExecStart' => $command,
-      'User'      => $user,
-      'Type'      => $type,
-    } + $_service_overrides,
+    service_entry => delete_undef_values({
+        'ExecStart' => $command, # if ensure present command is defined is checked above
+        'User'      => $user, # defaults apply
+        'Type'      => $type, # defaults apply
+    }) + $_service_overrides,
   }
   systemd::manage_unit { "${unit_name}_cron.timer":
     ensure      => $file_ensure,

--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppet-systemd",
-      "version_requirement": ">= 4.0.0 < 7.0.0"
+      "version_requirement": ">= 6.4.0 < 7.0.0"
     }
   ],
   "operatingsystem_support": [
@@ -30,7 +30,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 6.1.0 < 8.0.0"
+      "version_requirement": ">= 6.1.0 < 9.0.0"
     }
   ],
   "pdk-version": "3.0.1",

--- a/spec/defines/init_spec.rb
+++ b/spec/defines/init_spec.rb
@@ -106,7 +106,6 @@ describe 'systemd_cron' do
         let :params do
           {
             ensure: 'absent',
-            command: '/bin/true'
           }
         end
 
@@ -213,7 +212,6 @@ describe 'systemd_cron' do
         let :params do
           {
             on_boot_sec: 100,
-            on_unitactive_sec: 100,
             service_description: 'Print date',
             timer_description: 'Run date.service 100 seconds after boot',
           }


### PR DESCRIPTION
The pre 2.0.0 version was happily ignoring if the `command` parameter was not set, in the case that the `ensure` parameter was set to `absent`.
Although I tried my best to make the 2.0.0 version as backward compatible as possible I did overlook this scenario.
This change will restore the previous behaviour in this case.

Also with the release of `puppet-systemd` the puppet 8 check where re-enabled.